### PR TITLE
Resolved an uninitialized pointer issue in BcmI2cController _performR…

### DIFF
--- a/source/BcmI2cController.cpp
+++ b/source/BcmI2cController.cpp
@@ -374,6 +374,7 @@ HRESULT BcmI2cControllerClass::_performReads(I2cTransferClass* & pXfr)
     {
         // Prepare to access the read buffer.
         readXfr->resetRead();
+        readPtr = readXfr->getNextReadLocation();
 
         // Tell the controller how many bytes we expect to read.
         m_registers->DLEN.ALL_BITS = cmdsOutstanding;


### PR DESCRIPTION
…eads() method.
