### PR TITLE
I2C Fixes.

### DIFF
--- a/source/I2cTransaction.cpp
+++ b/source/I2cTransaction.cpp
@@ -36,7 +36,7 @@ HRESULT I2cTransactionClass::setAddress(ULONG slaveAdr)
 {
     HRESULT hr = S_OK;
 
-    if ((slaveAdr < 0x08) || (slaveAdr >= 0x77))
+    if ((slaveAdr < 0x08) || (slaveAdr > 0x77))
     {
         hr = DMAP_E_I2C_ADDRESS_OUT_OF_RANGE;
     }


### PR DESCRIPTION
Allow I2C transfer to address 0x77.
Allow EndTransmission() that was not preceded by BeginTransmission() to fix an external library.
