### PR TITLE
Add RPI2 and MBM pin numbers to Lighting via pins_arduino.h

### DIFF
--- a/source/BoardPins.h
+++ b/source/BoardPins.h
@@ -14,13 +14,6 @@
 #include "CY8C9540ASupport.h"
 #include "ExpanderDefs.h"
 
-#if defined(_M_ARM)
-// Temporary, special definitions to enable the PI2 Onboard LED.
-// This will be removed once it is in PinNumbers.h.
-#define GPIO_47 41         // PI2 onboard LED uses virtual "pin 41"
-#define LED_BUILTIN 41
-#endif // defined(_M_ARM)
-
 // Pin function type values.
 const UCHAR FUNC_NUL = 0x00;   ///< No function has been set
 const UCHAR FUNC_DIO = 0x01;   ///< Digital I/O function

--- a/source/DmapErrors.cpp
+++ b/source/DmapErrors.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  
+// Licensed under the BSD 2-Clause License.  
+// See License.txt in the project root for license information.
+
+#include "ErrorCodes.h"
+
+std::map<HRESULT, LPCWSTR> DmapErrors = {
+
+    { DMAP_E_PIN_FUNCTION_LOCKED                , L"A pin is already locked for use for a function that conflicts with the use requested." },
+    { DMAP_E_PIN_NUMBER_TOO_LARGE_FOR_BOARD     , L"A pin number was specified that is beyond the range of pins supported by the board." },
+    { DMAP_E_FUNCTION_NOT_SUPPORTED_ON_PIN      , L"A function has been requested on a pin that does not support that function." },
+    { DMAP_E_INVALID_PIN_DIRECTION              , L"A pin direction was specified that was neither INPUT nor OUPUT." },
+    { DMAP_E_DMAP_INTERNAL_ERROR                , L"An internal inconsistency in the DMap code has been found." },
+    { DMAP_E_INVALID_PIN_STATE_SPECIFIED        , L"A desited state for a pin was specified that was neither HIGH nor LOW." },
+    { DMAP_E_BOARD_TYPE_NOT_RECOGNIZED          , L"The board type could not be determined." },
+    { DMAP_E_INVALID_BOARD_TYPE_SPECIFIED       , L"An invalid board type was specified." },
+    { DMAP_E_INVALID_PORT_BIT_FOR_DEVICE        , L"The port/bit specified does not exist on the device." },
+    { DMAP_E_INVALID_LOCK_HANDLE_SPECIFIED      , L"An invalid handle was specified attempting to get a controller lock." },
+    { DMAP_E_TOO_MANY_DEVICES_MAPPED            , L"An attempt was made to map more than the maximum number of devices." },
+    { DMAP_E_DEVICE_NOT_FOUND_ON_SYSTEM         , L"The specified device could not be found on the system. Make sure the current driver is DMAP." },
+    { DMAP_E_I2C_ADDRESS_OUT_OF_RANGE           , L"The specified I2C address is outside the legal range for 7-bit I2C addresses." },
+    { DMAP_E_I2C_NO_OR_EMPTY_WRITE_BUFFER       , L"None or empty, write buffer was specified." },
+    { DMAP_E_I2C_NO_OR_ZERO_LENGTH_READ_BUFFER  , L"None or zero length, read buffer was specified." },
+    { DMAP_E_I2C_NO_CALLBACK_ROUTINE_SPECIFIED  , L"No callback routine was specified to be queued." },
+    { DMAP_E_I2C_BUS_LOCK_TIMEOUT               , L"More than 5 seconds elapsed waiting to acquire the I2C bus lock." },
+    { DMAP_E_I2C_READ_INCOMPLETE                , L"Fewer than the expected number of bytes were received on the I2C bus." },
+    { DMAP_E_I2C_EXTRA_DATA_RECEIVED            , L"More than the expected number of bytes were received on the I2C bus." },
+    { DMAP_E_I2C_OPERATION_INCOMPLETE           , L"One or more transfers remained undone at the end of the I2C operation." },
+    { DMAP_E_I2C_INVALID_BUS_NUMBER_SPECIFIED   , L"The I2C bus specified does not exist." },
+    { DMAP_E_I2C_TRANSFER_LENGTH_OVER_MAX       , L"The specified I2C transfer length is longer than the controller supports." },
+    { DMAP_E_ADC_DATA_FROM_WRONG_CHANNEL        , L"ADC data for a different channel than requested was received." },
+    { DMAP_E_ADC_DOES_NOT_HAVE_REQUESTED_CHANNEL, L"The ADC does not have the channel that has been requested." },
+    { DMAP_E_SPI_DATA_WIDTH_MISMATCH            , L"The width of data sent does not match the data width set on the SPI controller." },
+    { DMAP_E_SPI_BUS_REQUESTED_DOES_NOT_EXIST   , L"The specified BUS number does not exist on this board." },
+    { DMAP_E_SPI_MODE_SPECIFIED_IS_INVALID      , L"The SPI mode specified is not a legal SPI mode value (0-3)." },
+    { DMAP_E_SPI_SPEED_SPECIFIED_IS_INVALID     , L"The SPI speed specified is not in the supported range." },
+    { DMAP_E_SPI_BUFFER_TRANSFER_NOT_IMPLEMENTED, L"This SPI implementation does not support buffer transfers." },
+    { DMAP_E_SPI_DATA_WIDTH_SPECIFIED_IS_INVALID, L"The specified number of bits per transfer is not supported by the SPI controller." },
+    { DMAP_E_GPIO_PIN_IS_SET_TO_PWM             , L"A GPIO operation was performed on a pin configured as a PWM output." }
+};

--- a/source/DmapSupport.cpp
+++ b/source/DmapSupport.cpp
@@ -143,6 +143,7 @@ HRESULT GetControllerBaseAddress(PWCHAR deviceName, HANDLE & handle, PVOID & bas
             {
                 hr = DMAP_E_DEVICE_NOT_FOUND_ON_SYSTEM;
                 findCompleted->set();
+                return;
             }
 
             if (SUCCEEDED(hr))
@@ -166,6 +167,7 @@ HRESULT GetControllerBaseAddress(PWCHAR deviceName, HANDLE & handle, PVOID & bas
                     {
                         hr = DMAP_E_TOO_MANY_DEVICES_MAPPED;
                         findCompleted->set();
+                        return;
                     }
 
                     if (SUCCEEDED(hr))
@@ -184,7 +186,6 @@ HRESULT GetControllerBaseAddress(PWCHAR deviceName, HANDLE & handle, PVOID & bas
                             // into the address buffer by the I/O operation.
 
                             // hr should already be S_OK 
-                            // TODO: What happens if result != 8, fail?
                             if (result == 8)
                             {
                                 hr = S_OK;
@@ -350,7 +351,6 @@ HRESULT GetControllerLock(HANDLE & handle)
 
         create_task(device->SendIOControlAsync(LockCode, nullptr, nullptr)).then([&ioControlCompleted, &hr](UINT result)
         {
-            // TODO: Is this correct?
             hr = result;
 
             ioControlCompleted->set();
@@ -389,7 +389,6 @@ HRESULT ReleaseControllerLock(HANDLE & handle)
 
         create_task(device->SendIOControlAsync(UnlockCode, nullptr, nullptr)).then([&ioControlCompleted, &hr](UINT result)
         {
-            // TODO: Is this correct?
             hr = result;
 
             ioControlCompleted->set();

--- a/source/DmapSupport.cpp
+++ b/source/DmapSupport.cpp
@@ -7,41 +7,6 @@
 #include "ErrorCodes.h"
 #include "DmapSupport.h"
 
-std::map<HRESULT, LPCWSTR> DmapErrors = {
-
-    { DMAP_E_PIN_FUNCTION_LOCKED                , L"A pin is already locked for use for a function that conflicts with the use requested." },
-    { DMAP_E_PIN_NUMBER_TOO_LARGE_FOR_BOARD     , L"A pin number was specified that is beyond the range of pins supported by the board." },
-    { DMAP_E_FUNCTION_NOT_SUPPORTED_ON_PIN      , L"A function has been requested on a pin that does not support that function." },
-    { DMAP_E_INVALID_PIN_DIRECTION              , L"A pin direction was specified that was neither INPUT nor OUPUT." },
-    { DMAP_E_DMAP_INTERNAL_ERROR                , L"An internal inconsistency in the DMap code has been found." },
-    { DMAP_E_INVALID_PIN_STATE_SPECIFIED        , L"A desited state for a pin was specified that was neither HIGH nor LOW." },
-    { DMAP_E_BOARD_TYPE_NOT_RECOGNIZED          , L"The board type could not be determined." },
-    { DMAP_E_INVALID_BOARD_TYPE_SPECIFIED       , L"An invalid board type was specified." },
-    { DMAP_E_INVALID_PORT_BIT_FOR_DEVICE        , L"The port/bit specified does not exist on the device." },
-    { DMAP_E_INVALID_LOCK_HANDLE_SPECIFIED      , L"An invalid handle was specified attempting to get a controller lock." },
-    { DMAP_E_TOO_MANY_DEVICES_MAPPED            , L"An attempt was made to map more than the maximum number of devices." },
-    { DMAP_E_DEVICE_NOT_FOUND_ON_SYSTEM         , L"The specified device could not be found on the system. Make sure the current driver is DMAP." },
-    { DMAP_E_I2C_ADDRESS_OUT_OF_RANGE           , L"The specified I2C address is outside the legal range for 7-bit I2C addresses." },
-    { DMAP_E_I2C_NO_OR_EMPTY_WRITE_BUFFER       , L"None or empty, write buffer was specified." },
-    { DMAP_E_I2C_NO_OR_ZERO_LENGTH_READ_BUFFER  , L"None or zero length, read buffer was specified." },
-    { DMAP_E_I2C_NO_CALLBACK_ROUTINE_SPECIFIED  , L"No callback routine was specified to be queued." },
-    { DMAP_E_I2C_BUS_LOCK_TIMEOUT               , L"More than 5 seconds elapsed waiting to acquire the I2C bus lock." },
-    { DMAP_E_I2C_READ_INCOMPLETE                , L"Fewer than the expected number of bytes were received on the I2C bus." },
-    { DMAP_E_I2C_EXTRA_DATA_RECEIVED            , L"More than the expected number of bytes were received on the I2C bus." },
-    { DMAP_E_I2C_OPERATION_INCOMPLETE           , L"One or more transfers remained undone at the end of the I2C operation." },
-    { DMAP_E_I2C_INVALID_BUS_NUMBER_SPECIFIED   , L"The I2C bus specified does not exist." },
-    { DMAP_E_I2C_TRANSFER_LENGTH_OVER_MAX       , L"The specified I2C transfer length is longer than the controller supports." },
-    { DMAP_E_ADC_DATA_FROM_WRONG_CHANNEL        , L"ADC data for a different channel than requested was received." },
-    { DMAP_E_ADC_DOES_NOT_HAVE_REQUESTED_CHANNEL, L"The ADC does not have the channel that has been requested." },
-    { DMAP_E_SPI_DATA_WIDTH_MISMATCH            , L"The width of data sent does not match the data width set on the SPI controller." },
-    { DMAP_E_SPI_BUS_REQUESTED_DOES_NOT_EXIST   , L"The specified BUS number does not exist on this board." },
-    { DMAP_E_SPI_MODE_SPECIFIED_IS_INVALID      , L"The SPI mode specified is not a legal SPI mode value (0-3)." },
-    { DMAP_E_SPI_SPEED_SPECIFIED_IS_INVALID     , L"The SPI speed specified is not in the supported range." },
-    { DMAP_E_SPI_BUFFER_TRANSFER_NOT_IMPLEMENTED, L"This SPI implementation does not support buffer transfers." },
-    { DMAP_E_SPI_DATA_WIDTH_SPECIFIED_IS_INVALID, L"The specified number of bits per transfer is not supported by the SPI controller." },
-    { DMAP_E_GPIO_PIN_IS_SET_TO_PWM             , L"A GPIO operation was performed on a pin configured as a PWM output." }
-};
-
 #if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)  // If building a UWP app
 using namespace Windows::Devices::Enumeration;
 using namespace Windows::Devices::Custom;
@@ -383,19 +348,13 @@ HRESULT GetControllerLock(HANDLE & handle)
 
         std::shared_ptr<Concurrency::event> ioControlCompleted = std::make_shared<Concurrency::event>();
 
-        auto workItem = ref new WorkItemHandler(
-            [&device, &hr, &ioControlCompleted](IAsyncAction^ workItem)
+        create_task(device->SendIOControlAsync(LockCode, nullptr, nullptr)).then([&ioControlCompleted, &hr](UINT result)
         {
-            create_task(device->SendIOControlAsync(LockCode, nullptr, nullptr)).then([&ioControlCompleted, &hr](UINT result)
-            {
-                // TODO: Is this correct?
-                hr = result;
+            // TODO: Is this correct?
+            hr = result;
 
-                ioControlCompleted->set();
-            });
+            ioControlCompleted->set();
         });
-
-        auto asyncAction = ThreadPool::RunAsync(workItem);
 
         ioControlCompleted->wait();
 
@@ -428,19 +387,13 @@ HRESULT ReleaseControllerLock(HANDLE & handle)
 
         std::shared_ptr<Concurrency::event> ioControlCompleted = std::make_shared<Concurrency::event>();
 
-        auto workItem = ref new WorkItemHandler(
-            [&device, &hr, &ioControlCompleted](IAsyncAction^ workItem)
+        create_task(device->SendIOControlAsync(UnlockCode, nullptr, nullptr)).then([&ioControlCompleted, &hr](UINT result)
         {
-            create_task(device->SendIOControlAsync(UnlockCode, nullptr, nullptr)).then([&ioControlCompleted, &hr](UINT result)
-            {
-                // TODO: Is this correct?
-                hr = result;
+            // TODO: Is this correct?
+            hr = result;
 
-                ioControlCompleted->set();
-            });
+            ioControlCompleted->set();
         });
-
-        auto asyncAction = ThreadPool::RunAsync(workItem);
 
         ioControlCompleted->wait();
 

--- a/source/Microsoft.IoT.Lightning.nuspec
+++ b/source/Microsoft.IoT.Lightning.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.IoT.Lightning</id>
-    <version>1.0.0-alpha</version>
+    <version>1.0.1-alpha</version>
     <title>Microsoft IoT Lightning SDK</title>
     <authors>Microsoft Open Technologies, Inc.</authors>
     <owners>Microsoft Open Technologies, Inc.</owners>
@@ -15,7 +15,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>lightning arduino microsoft native nativepackage</tags>
     <dependencies>
-        <dependency id="Microsoft.IoT.SDKFromArduino" version="(,1.0.1]"/>
+        <dependency id="Microsoft.IoT.SDKFromArduino" version="[1.0.1,)"/>
     </dependencies>
   </metadata>
 </package>

--- a/source/Microsoft.IoT.Lightning.targets
+++ b/source/Microsoft.IoT.Lightning.targets
@@ -21,6 +21,7 @@
     <LightningSources Include="$(MSBuildThisFileDirectory)\Source\BtSpiController.cpp" />
     <LightningSources Include="$(MSBuildThisFileDirectory)\Source\CY8C9540ASupport.cpp" />
     <LightningSources Include="$(MSBuildThisFileDirectory)\Source\DmapSupport.cpp" />
+    <LightningSources Include="$(MSBuildThisFileDirectory)\Source\DmapErrors.cpp" />
     <LightningSources Include="$(MSBuildThisFileDirectory)\Source\eeprom.cpp" />
     <LightningSources Include="$(MSBuildThisFileDirectory)\Source\GpioController.cpp" />
     <LightningSources Include="$(MSBuildThisFileDirectory)\Source\I2c.cpp" />

--- a/source/arduino.h
+++ b/source/arduino.h
@@ -37,6 +37,7 @@
 #include "binary.h"
 #include "wire.h"
 #include "Adc.h"
+#include "pins_arduino.h"
 
 #include <memory>
 #include <map>

--- a/source/pins_arduino.h
+++ b/source/pins_arduino.h
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.  
+// Licensed under the BSD 2-Clause License.  
+// See License.txt in the project root for license information.
+
+#ifndef _PINS_ARDUINO_H_
+#define _PINS_ARDUINO_H_
+
+
+#if defined(_M_IX86) || defined(_M_X64)
+
+// Pin numbers mappings for MinnowBoard Max
+
+const static uint8_t GPIO0 = 21;
+const static uint8_t GPIO1 = 23;
+const static uint8_t GPIO2 = 25;
+const static uint8_t GPIO3 = 14;
+const static uint8_t GPIO4 = 16;
+const static uint8_t GPIO5 = 18;
+const static uint8_t GPIO6 = 20;
+const static uint8_t GPIO7 = 22;
+const static uint8_t GPIO8 = 24;
+const static uint8_t GPIO9 = 26;
+const static uint8_t SCL = 13;
+const static uint8_t SDA = 15;
+const static uint8_t CS0 = 5;
+const static uint8_t MISO = 7;
+const static uint8_t MOSI = 9;
+const static uint8_t SCLK = 11;
+const static uint8_t CTS1 = 10;
+const static uint8_t RTS1 = 12;
+const static uint8_t RX1 = 8;
+const static uint8_t TX1 = 6;
+const static uint8_t RX2 = 19;
+const static uint8_t TX2 = 17;
+
+#elif defined (_M_ARM)
+
+// Pin numbers mappings for Raspberry Pi2
+
+const static uint8_t GPIO2 = 3;
+const static uint8_t GPIO3 = 5;
+const static uint8_t GPIO4 = 7;
+const static uint8_t GPIO5 = 29;
+const static uint8_t GPIO6 = 31;
+const static uint8_t GPIO7 = 26;
+const static uint8_t GPIO8 = 24;
+const static uint8_t GPIO9 = 21;
+const static uint8_t GPIO10 = 19;
+const static uint8_t GPIO11 = 23;
+const static uint8_t GPIO12 = 32;
+const static uint8_t GPIO13 = 33;
+const static uint8_t GPIO14 = 8;
+const static uint8_t GPIO15 = 10;
+const static uint8_t GPIO16 = 36;
+const static uint8_t GPIO17 = 11;
+const static uint8_t GPIO18 = 12;
+const static uint8_t GPIO19 = 35;
+const static uint8_t GPIO20 = 38;
+const static uint8_t GPIO21 = 40;
+const static uint8_t GPIO22 = 15;
+const static uint8_t GPIO23 = 16;
+const static uint8_t GPIO24 = 18;
+const static uint8_t GPIO25 = 22;
+const static uint8_t GPIO26 = 37;
+const static uint8_t GPIO27 = 13;
+const static uint8_t GPIO47 = 41;
+const static uint8_t GCLK = 7;
+const static uint8_t GEN0 = 11;
+const static uint8_t GEN1 = 12;
+const static uint8_t GEN2 = 13;
+const static uint8_t GEN3 = 15;
+const static uint8_t GEN4 = 16;
+const static uint8_t GEN5 = 18;
+const static uint8_t SCL1 = 5;
+const static uint8_t SDA1 = 3;
+const static uint8_t CS0 = 24;
+const static uint8_t CS1 = 26;
+const static uint8_t SCLK = 23;
+const static uint8_t MISO = 21;
+const static uint8_t MOSI = 19;
+const static uint8_t RXD = 10;
+const static uint8_t TXD = 8;
+
+static const uint8_t LED_BUILTIN = 41;
+
+#endif // defined (_M_ARM)
+
+#endif // _PINS_ARDUINO_H_


### PR DESCRIPTION
Some cleanup in the package as well, including updating the nuspec
version number and dependency to make upgrades easy and moving DMAP
Errors to a its own cpp file.
Optimizing DMAP lock/unlock async code path.
