### PR TITLE
removed PWM_MAX_DUTYCYCLE define which was used for Arduino internal …

### DIFF
--- a/source/ArduinoCommon.h
+++ b/source/ArduinoCommon.h
@@ -29,8 +29,6 @@ const UCHAR CHANGE = 0x01;
 const UCHAR FALLING = 0x02;
 const UCHAR RISING = 0x03;
 
-const uint16_t PWM_MAX_DUTYCYCLE = 0xffff;
-
 // Pin name to number mapping.
 const UCHAR D0 = 0;
 const UCHAR D1 = 1;


### PR DESCRIPTION
…logic, but not used in our implementation

this value can cause confusion when working with PWM as it is not valid for any real value.
