### PR TITLE
Update nuget version

### DIFF
--- a/source/DMap.h
+++ b/source/DMap.h
@@ -46,7 +46,7 @@ DEFINE_GUID(GUID_DEVINTERFACE_DMap, 0x109b86ad, 0xf53d, 0x4b76, 0xaa, 0x5f, 0x82
 
 typedef struct _DMAP_MAPMEMORY_OUTPUT_BUFFER
 {
-    uint64_t Address;
+    void*    Address;
     uint32_t Length;
 } DMAP_MAPMEMORY_OUTPUT_BUFFER, *PDMAP_MAPMEMORY_OUTPUT_BUFFER;
 

--- a/source/Microsoft.IoT.Lightning.nuspec
+++ b/source/Microsoft.IoT.Lightning.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.IoT.Lightning</id>
-    <version>1.0.3-alpha</version>
+    <version>1.0.3</version>
     <title>Microsoft IoT Lightning SDK</title>
     <authors>Microsoft Open Technologies, Inc.</authors>
     <owners>Microsoft Open Technologies, Inc.</owners>


### PR DESCRIPTION
Additionally fix Lightning to use current DMAP driver definition for address, void\* instead of uint64_t
