### PR TITLE
Fix DebounceTimeout

### DIFF
--- a/Providers/GpioDeviceProvider.h
+++ b/Providers/GpioDeviceProvider.h
@@ -124,7 +124,7 @@ namespace Microsoft {
                                 }
 
                                 auto eventTimeDiff = (InfoPtr->EventTime - pin->_lastEventTime) / pin->_clockFrequency;
-                                if (eventTimeDiff >= pin->_DebounceTimeout.Duration || (eventTimeDiff > 0 && InfoPtr->NewState != pin->_lastEventState))
+                                if (eventTimeDiff >= pin->_DebounceTimeout.Duration || pin->_DebounceTimeout.Duration == 0)
                                 {
 
                                     pin->_ValueChangedInternal(pin, ref new GpioPinProviderValueChangedEventArgs((InfoPtr->NewState == 0) ?


### PR DESCRIPTION
This PR implements @siochs suggestion from https://github.com/ms-iot/lightning/issues/44
All credits for the idea got to him.

After some testing it seemed to fix the issues I had with multiple interrupts for each pull down event.
However somebody should probably ask the original developer at Microsoft what the intention of `(eventTimeDiff > 0 && InfoPtr->NewState != pin->_lastEventState)` was. It seems like it was put in place deliberately to fix something.