### PR TITLE
Fix GPIO Interrupts on MinnowBoard platform devices.

### DIFF
--- a/Providers/GpioDeviceProvider.h
+++ b/Providers/GpioDeviceProvider.h
@@ -106,7 +106,6 @@ namespace Microsoft {
                         _clockFrequency = double(li.QuadPart) / 100000.0; // Calaculate device clock freq in 100ns, same resolution as debounce
                         
                         HRESULT hr = g_pins.getBoardType(_BoardType);
-
                         if (FAILED(hr))
                         {
                             LightningProvider::ThrowError(hr, L"An error occurred determining board type.");

--- a/Providers/GpioDeviceProvider.h
+++ b/Providers/GpioDeviceProvider.h
@@ -104,8 +104,8 @@ namespace Microsoft {
                         LARGE_INTEGER li;
                         QueryPerformanceFrequency(&li);
                         _clockFrequency = double(li.QuadPart) / 100000.0; // Calaculate device clock freq in 100ns, same resolution as debounce
-
-						g_pins.getBoardType(_BoardType);
+                        
+                        g_pins.getBoardType(_BoardType);
                     }
 
                 private:
@@ -120,31 +120,31 @@ namespace Microsoft {
                                 Platform::Object^ o = reinterpret_cast<Platform::Object^>((IInspectable*)context);
                                 LightningGpioPinProvider^ pin = reinterpret_cast<LightningGpioPinProvider^>(o);
 
-								// The returned interrupt number is equal to the port bit of the pin on RPi, which is the same as the PinNumber.
-								// On MBM or Turbot, the returned interrupt number is equal to the mapped pin number.
-								switch (pin->_BoardType)
-								{
-								case BoardPinsClass::BOARD_TYPE::PI2_BARE:
-									if (pin == nullptr || InfoPtr->IntNo != pin->_PinNumber)
-									{
-										return;
-									}
-									break;
-								case BoardPinsClass::BOARD_TYPE::MBM_IKA_LURE:
-									if (pin == nullptr || InfoPtr->IntNo != pin->_MappedPinNumber)
-									{
-										return;
-									}
-									break;
-								case BoardPinsClass::BOARD_TYPE::MBM_BARE:
-									if (pin == nullptr || InfoPtr->IntNo != pin->_MappedPinNumber)
-									{
-										return;
-									}
-									break;
-								default:
-									return;
-								}
+                                // The returned interrupt number is equal to the port bit of the pin on RPi, which is the same as the PinNumber.
+                                // On MBM or Turbot, the returned interrupt number is equal to the mapped pin number.
+                                switch (pin->_BoardType)
+                                {
+                                case BoardPinsClass::BOARD_TYPE::PI2_BARE:
+                                    if (pin == nullptr || InfoPtr->IntNo != pin->_PinNumber)
+                                    {
+                                        return;
+                                    }
+                                    break;
+                                case BoardPinsClass::BOARD_TYPE::MBM_IKA_LURE:
+                                    if (pin == nullptr || InfoPtr->IntNo != pin->_MappedPinNumber)
+                                    {
+                                        return;
+                                    }
+                                    break;
+                                case BoardPinsClass::BOARD_TYPE::MBM_BARE:
+                                    if (pin == nullptr || InfoPtr->IntNo != pin->_MappedPinNumber)
+                                    {
+                                        return;
+                                    }
+                                    break;
+                                default:
+                                    return;
+                                }
                                 
                                 auto eventTimeDiff = (InfoPtr->EventTime - pin->_lastEventTime) / pin->_clockFrequency;
                                 if (eventTimeDiff >= pin->_DebounceTimeout.Duration || pin->_DebounceTimeout.Duration == 0)
@@ -167,7 +167,7 @@ namespace Microsoft {
                     ProviderGpioSharingMode _SharingMode;
                     ProviderGpioPinDriveMode _DriveMode;
                     TimeSpan _DebounceTimeout;
-					BoardPinsClass::BOARD_TYPE _BoardType;
+                    BoardPinsClass::BOARD_TYPE _BoardType;
 
                     // Used to keep track of interrupts
                     long long _lastEventTime;

--- a/Providers/GpioDeviceProvider.h
+++ b/Providers/GpioDeviceProvider.h
@@ -105,7 +105,12 @@ namespace Microsoft {
                         QueryPerformanceFrequency(&li);
                         _clockFrequency = double(li.QuadPart) / 100000.0; // Calaculate device clock freq in 100ns, same resolution as debounce
                         
-                        g_pins.getBoardType(_BoardType);
+                        HRESULT hr = g_pins.getBoardType(_BoardType);
+
+                        if (FAILED(hr))
+                        {
+                            LightningProvider::ThrowError(hr, L"An error occurred determining board type.");
+                        }
                     }
 
                 private:

--- a/Providers/GpioDeviceProvider.h
+++ b/Providers/GpioDeviceProvider.h
@@ -104,6 +104,8 @@ namespace Microsoft {
                         LARGE_INTEGER li;
                         QueryPerformanceFrequency(&li);
                         _clockFrequency = double(li.QuadPart) / 100000.0; // Calaculate device clock freq in 100ns, same resolution as debounce
+
+						g_pins.getBoardType(_BoardType);
                     }
 
                 private:
@@ -118,11 +120,32 @@ namespace Microsoft {
                                 Platform::Object^ o = reinterpret_cast<Platform::Object^>((IInspectable*)context);
                                 LightningGpioPinProvider^ pin = reinterpret_cast<LightningGpioPinProvider^>(o);
 
-                                if (pin == nullptr || InfoPtr->IntNo != pin->_PinNumber)
-                                {
-                                    return;
-                                }
-
+								// The returned interrupt number is equal to the port bit of the pin on RPi, which is the same as the PinNumber.
+								// On MBM or Turbot, the returned interrupt number is equal to the mapped pin number.
+								switch (pin->_BoardType)
+								{
+								case BoardPinsClass::BOARD_TYPE::PI2_BARE:
+									if (pin == nullptr || InfoPtr->IntNo != pin->_PinNumber)
+									{
+										return;
+									}
+									break;
+								case BoardPinsClass::BOARD_TYPE::MBM_IKA_LURE:
+									if (pin == nullptr || InfoPtr->IntNo != pin->_MappedPinNumber)
+									{
+										return;
+									}
+									break;
+								case BoardPinsClass::BOARD_TYPE::MBM_BARE:
+									if (pin == nullptr || InfoPtr->IntNo != pin->_MappedPinNumber)
+									{
+										return;
+									}
+									break;
+								default:
+									return;
+								}
+                                
                                 auto eventTimeDiff = (InfoPtr->EventTime - pin->_lastEventTime) / pin->_clockFrequency;
                                 if (eventTimeDiff >= pin->_DebounceTimeout.Duration || pin->_DebounceTimeout.Duration == 0)
                                 {
@@ -144,6 +167,7 @@ namespace Microsoft {
                     ProviderGpioSharingMode _SharingMode;
                     ProviderGpioPinDriveMode _DriveMode;
                     TimeSpan _DebounceTimeout;
+					BoardPinsClass::BOARD_TYPE _BoardType;
 
                     // Used to keep track of interrupts
                     long long _lastEventTime;

--- a/source/BtSpiController.h
+++ b/source/BtSpiController.h
@@ -419,7 +419,7 @@ private:
 /**
 Transfer a number of bits on the SPI bus.
 \param[in] dataOut Data to send on the SPI bus
-\param[out] datIn The data reaceived on the SPI bus
+\param[out] datIn The data received on the SPI bus
 \param[in] bits The number of bits to transfer in each direction on the bus.  This must agree with
 the data width set previously.
 \return HRESULT success or error code.


### PR DESCRIPTION
Interrupts only worked on RPi before because of the difference in how pins were referred to between RPi and MBM. On RPi, the IntNo is the pin's port number(see BoardPins.cpp), which is the same as the PinNumber. On MinnowBoard, the returned IntNo is the same as MappedPinNumber.

To fix this, I added a member called BoardType that grabs the BoardPinsClass::BOARD_TYPE on initialization. Another approach would be to use preprocessor architecture checks and assume RPi==ARM and MBM==x86,64 since that is ultimately what BOARD_TYPE is, but if that assumption breaks in the future, we would have to switch to this type of approach anyway. 

In my testing, there wasn't appreciable difference in max interrupt frequency using the switch statement vs calling the correct pin type for the board directly.