### PR TITLE
Beter initialization for BoardType

### DIFF
--- a/Providers/GpioDeviceProvider.cpp
+++ b/Providers/GpioDeviceProvider.cpp
@@ -75,7 +75,7 @@ IGpioPinProvider^ LightningGpioControllerProvider::OpenPinProviderNoMapping(int 
         LightningProvider::ThrowError(hr, L"Invalid function for pin.");
     }
 
-    return ref new LightningGpioPinProvider(pin, mappedPin, sharingMode);
+    return ref new LightningGpioPinProvider(pin, mappedPin, sharingMode, this->_boardType);
 }
 
 IVectorView<IGpioControllerProvider^>^ LightningGpioProvider::GetControllers(

--- a/Providers/GpioDeviceProvider.h
+++ b/Providers/GpioDeviceProvider.h
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 #pragma once
-#include "Provider.h"
 
 using namespace Windows::Devices::Gpio::Provider;
 
@@ -109,7 +108,7 @@ namespace Microsoft {
                         HRESULT hr = g_pins.getBoardType(_BoardType);
                         if (FAILED(hr))
                         {
-                            Microsoft::IoT::Lightning::Providers::LightningProvider::ThrowError(hr, L"An error occurred determining board type.");
+                            LightningProvider::ThrowError(hr, L"An error occurred determining board type.");
                         }
                     }
 

--- a/Providers/GpioDeviceProvider.h
+++ b/Providers/GpioDeviceProvider.h
@@ -84,10 +84,11 @@ namespace Microsoft {
                     virtual ~LightningGpioPinProvider() { }
 
                 internal:
-                    LightningGpioPinProvider(int pin, int mappedPin, ProviderGpioSharingMode sharingMode) :
+                    LightningGpioPinProvider(int pin, int mappedPin, ProviderGpioSharingMode sharingMode, BoardPinsClass::BOARD_TYPE boardType) :
                         _MappedPinNumber(mappedPin),
                         _PinNumber(pin),
                         _SharingMode(sharingMode),
+                        _BoardType(boardType),
                         _DriveMode(ProviderGpioPinDriveMode::Output),
                         _lastEventTime(0),
                         _lastEventState(0),
@@ -104,12 +105,6 @@ namespace Microsoft {
                         LARGE_INTEGER li;
                         QueryPerformanceFrequency(&li);
                         _clockFrequency = double(li.QuadPart) / 100000.0; // Calaculate device clock freq in 100ns, same resolution as debounce
-                        
-                        HRESULT hr = g_pins.getBoardType(_BoardType);
-                        if (FAILED(hr))
-                        {
-                            LightningProvider::ThrowError(hr, L"An error occurred determining board type.");
-                        }
                     }
 
                 private:

--- a/Providers/GpioDeviceProvider.h
+++ b/Providers/GpioDeviceProvider.h
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 #pragma once
+#include "Provider.h"
 
 using namespace Windows::Devices::Gpio::Provider;
 
@@ -108,7 +109,7 @@ namespace Microsoft {
                         HRESULT hr = g_pins.getBoardType(_BoardType);
                         if (FAILED(hr))
                         {
-                            LightningProvider::ThrowError(hr, L"An error occurred determining board type.");
+                            Microsoft::IoT::Lightning::Providers::LightningProvider::ThrowError(hr, L"An error occurred determining board type.");
                         }
                     }
 


### PR DESCRIPTION
The parent class already has a member board type that can be passed into the internal constructor. Remove the boardtype initialization in LightningGpioPinProvider and pass it on from LightningGpioControllerProvider